### PR TITLE
regex filter

### DIFF
--- a/core/templates.yml
+++ b/core/templates.yml
@@ -39,7 +39,7 @@ keys:
         type: str
     name:
         type: str
-        filter_by: alphanumeric
+        filter_by: '^[a-zA-Z0-9_-]+$'
     iteration:
         type: int
     version:


### PR DESCRIPTION
I just tested this so that I can allow dashes and underscores in filenames but disallow the others. Effectively an alphanumeric with the two character exceptions.